### PR TITLE
Fixes VDH and VDL voltages for 750_T7 displays

### DIFF
--- a/src/epd/GxEPD2_750_T7.cpp
+++ b/src/epd/GxEPD2_750_T7.cpp
@@ -537,9 +537,10 @@ void GxEPD2_750_T7::_InitDisplay()
   if (_hibernating) _reset();
   _writeCommand(0x01); // POWER SETTING
   _writeData (0x07);
-  _writeData (0x07); // VGH=20V,VGL=-20V
-  _writeData (0x3f); // VDH=15V
-  _writeData (0x3f); // VDL=-15V
+  _transfer(0x17); // VGH=20V,VGL=-20V
+  _transfer(0x3a); // VDH=14V
+  _transfer(0x3a); // VDL=-14V
+  _transfer(0x03); // VDHR=3V
   _writeCommand(0x00); //PANEL SETTING
   _writeData(0x1f); //KW: 3f, KWR: 2F, BWROTP: 0f, BWOTP: 1f
   _writeCommand(0x61); //tres


### PR DESCRIPTION
Hello,
we found out that Power settings of GoodDisplay 750_T7 are invalid. According to technical specification VDH and VDL should be 14V and -14V (instead of 15V and -15V). This small PR fixes it.

Original code works, but after 100+ re-draws, weird artefacts will be shown - mostly grays will not work - it will be all black.

Correct voltage: - please see tile separators for example - it should be light gray. Thats correct
![Correct](https://github.com/ZinggJM/GxEPD2_4G/assets/1753433/5a4c8fb1-278c-4341-afd5-28872cb198f8)

Wrong voltage:
![Wrong](https://github.com/ZinggJM/GxEPD2_4G/assets/1753433/2aa4dbce-cc07-4c9f-8501-11847c05a679)

