### PR TITLE
Added support for GDEY075T7 480x800

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@
 - GDEY042T81     4.2" b/w 400x300, SSD1683
 - GDEQ0426T82    4.26" b/w 800x480, SSD1677
 - GDEW075T7      7.5" b/w 800x480, EK79655 (GD7965)
+- GDEY075T7      7.5" b/w 800x480
+
+### Version 1.0.8-dev
+- added support for GDEY075T7 800x480
 
 ### Version 1.0.7
 - added support for GDEY0154D67 200x200

--- a/src/GxEPD2_4G_4G.h
+++ b/src/GxEPD2_4G_4G.h
@@ -66,6 +66,7 @@
 #include "gdeq/GxEPD2_426_GDEQ0426T82.h"
 #endif
 #include "epd/GxEPD2_750_T7.h"
+#include "epd/GxEPD2_750_T7Y.h"
 
 template<typename GxEPD2_Type, const uint16_t page_height>
 class GxEPD2_4G_4G_R : public GxEPD2_4G_GFX_BASE_CLASS

--- a/src/GxEPD2_4G_BW.h
+++ b/src/GxEPD2_4G_BW.h
@@ -66,6 +66,7 @@
 #include "gdeq/GxEPD2_426_GDEQ0426T82.h"
 #endif
 #include "epd/GxEPD2_750_T7.h"
+#include "epd/GxEPD2_750_T7Y.h"
 
 template<typename GxEPD2_Type, const uint16_t page_height>
 class GxEPD2_4G_BW_R : public GxEPD2_4G_GFX_BASE_CLASS

--- a/src/epd/GxEPD2_750_T7Y.cpp
+++ b/src/epd/GxEPD2_750_T7Y.cpp
@@ -1,0 +1,748 @@
+// Based on GxEPD2_750_T7.cpp
+// Panel: GDEY075T7 : https://www.good-display.com/product/396.html
+//
+// Display Library for SPI e-paper panels from Dalian Good Display and boards from Waveshare.
+// Requires HW SPI and Adafruit_GFX. Caution: the e-paper panels require 3.3V supply AND data lines!
+//
+// based on Demo Example from Good Display:
+// Panel: GDEW075T7 : http://www.e-paper-display.com/products_detail/productId=456.html
+// Controller: GD7965 : http://www.e-paper-display.com/download_detail/downloadsId=821.html
+//
+// Author: Jean-Marc Zingg
+//
+// Version: see library.properties
+//
+// Library: https://github.com/ZinggJM/GxEPD2
+
+#include "GxEPD2_750_T7Y.h"
+
+GxEPD2_750_T7Y::GxEPD2_750_T7Y(int16_t cs, int16_t dc, int16_t rst, int16_t busy) :
+  GxEPD2_4G_EPD(cs, dc, rst, busy, LOW, 10000000, WIDTH, HEIGHT, panel, hasColor, hasPartialUpdate, hasFastPartialUpdate)
+{
+  _refresh_mode = full_refresh;
+}
+
+void GxEPD2_750_T7Y::clearScreen(uint8_t value)
+{
+  writeScreenBuffer(value);
+  refresh(true);
+  if (_refresh_mode != grey_refresh) writeScreenBuffer(value);
+}
+
+void GxEPD2_750_T7Y::writeScreenBuffer(uint8_t value)
+{
+  _initial_write = false; // initial full screen buffer clean done
+  if (_refresh_mode == full_refresh) _Init_Part();
+  _writeCommand(0x13); // set current
+  for (uint32_t i = 0; i < uint32_t(WIDTH) * uint32_t(HEIGHT) / 8; i++)
+  {
+    _writeData(value);
+  }
+  if (_initial_refresh || (_refresh_mode == grey_refresh))
+  {
+    _writeCommand(0x10); // preset previous
+    for (uint32_t i = 0; i < uint32_t(WIDTH) * uint32_t(HEIGHT) / 8; i++)
+    {
+      _writeData(0xFF); // 0xFF is white
+    }
+  }
+}
+
+void GxEPD2_750_T7Y::writeImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (_initial_write) writeScreenBuffer(); // initial full screen buffer clean
+  delay(1); // yield() to avoid WDT on ESP8266 and ESP32
+  uint16_t wb = (w + 7) / 8; // width bytes, bitmaps are padded
+  x -= x % 8; // byte boundary
+  w = wb * 8; // byte boundary
+  int16_t x1 = x < 0 ? 0 : x; // limit
+  int16_t y1 = y < 0 ? 0 : y; // limit
+  uint16_t w1 = x + w < int16_t(WIDTH) ? w : int16_t(WIDTH) - x; // limit
+  uint16_t h1 = y + h < int16_t(HEIGHT) ? h : int16_t(HEIGHT) - y; // limit
+  int16_t dx = x1 - x;
+  int16_t dy = y1 - y;
+  w1 -= dx;
+  h1 -= dy;
+  if ((w1 <= 0) || (h1 <= 0)) return;
+  if (_refresh_mode == grey_refresh) _Force_Init_Full();
+  else if (_refresh_mode == full_refresh) _Init_Part();
+  _writeCommand(0x91); // partial in
+  _setPartialRamArea(x1, y1, w1, h1);
+  _writeCommand(0x13);
+  for (uint16_t i = 0; i < h1; i++)
+  {
+    for (uint16_t j = 0; j < w1 / 8; j++)
+    {
+      uint8_t data;
+      // use wb, h of bitmap for index!
+      uint16_t idx = mirror_y ? j + dx / 8 + uint16_t((h - 1 - (i + dy))) * wb : j + dx / 8 + uint16_t(i + dy) * wb;
+      if (pgm)
+      {
+#if defined(__AVR) || defined(ESP8266) || defined(ESP32)
+        data = pgm_read_byte(&bitmap[idx]);
+#else
+        data = bitmap[idx];
+#endif
+      }
+      else
+      {
+        data = bitmap[idx];
+      }
+      if (invert) data = ~data;
+      _writeData(data);
+    }
+  }
+  _writeCommand(0x92); // partial out
+  delay(1); // yield() to avoid WDT on ESP8266 and ESP32
+}
+
+void GxEPD2_750_T7Y::writeImage_4G(const uint8_t bitmap[], uint8_t bpp, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  uint16_t ppb = (bpp == 2 ? 4 : (bpp == 4 ? 2 : (bpp == 8 ? 1 : 0)));
+  uint8_t mask = (bpp == 2 ? 0xC0 : (bpp == 4 ? 0xF0 : 0xFF));
+  uint8_t grey1 = (bpp == 2 ? 0x80 : 0xA0); // demo limit for 4bpp
+  if (ppb == 0) return;
+  if (_initial_write) writeScreenBuffer(); // initial full screen buffer clean
+  delay(1); // yield() to avoid WDT on ESP8266 and ESP32
+  int16_t wbc = (w + 7) / 8; // width bytes on controller
+  x -= x % 8; // byte boundary on controller
+  w = wbc * 8; // byte boundary on controller
+  int16_t wb = (w + ppb - 1) / ppb; // width bytes of bitmap, bitmaps are padded
+  int16_t x1 = x < 0 ? 0 : x; // limit
+  int16_t y1 = y < 0 ? 0 : y; // limit
+  uint16_t w1 = x + w < int16_t(WIDTH) ? w : int16_t(WIDTH) - x; // limit
+  uint16_t h1 = y + h < int16_t(HEIGHT) ? h : int16_t(HEIGHT) - y; // limit
+  int16_t dx = x1 - x;
+  int16_t dy = y1 - y;
+  w1 -= dx;
+  h1 -= dy;
+  if ((w1 <= 0) || (h1 <= 0)) return;
+  _Init_4G();
+  _writeCommand(0x91); // partial in
+  _setPartialRamArea(x1, y1, w1, h1);
+  _writeCommand(0x10);
+  for (uint16_t i = 0; i < h1; i++) // lines
+  {
+    for (uint16_t j = 0; j < w1 / ppb; j += bpp) // out bytes
+    {
+      uint8_t out_byte = 0;
+      for (uint16_t k = 0; k < bpp; k++) // in bytes (bpp per out byte)
+      {
+        uint8_t in_byte;
+        // use wb, h of bitmap for index!
+        uint32_t idx = mirror_y ? j + k + dx / ppb + uint32_t((h - 1 - (i + dy))) * wb : j + k + dx / ppb + uint32_t(i + dy) * wb;
+        if (pgm)
+        {
+#if defined(__AVR) || defined(ESP8266) || defined(ESP32)
+          in_byte = pgm_read_byte(&bitmap[idx]);
+#else
+          in_byte = bitmap[idx];
+#endif
+        }
+        else
+        {
+          in_byte = bitmap[idx];
+        }
+        if (invert) in_byte = ~in_byte;
+        for (uint16_t n = 0; n < ppb; n++) // bits, nibbles (ppb per in byte)
+        {
+          out_byte <<= 1;
+          uint8_t nibble = in_byte & mask;
+          if (nibble == mask) out_byte |= 0x01;//white
+          else if (nibble == 0x00) out_byte |= 0x00;  //black
+          else if (nibble >= grey1) out_byte |= 0x01;  //gray1
+          else out_byte |= 0x00; //gray2
+          in_byte <<= bpp;
+        }
+      }
+      _writeData(out_byte);
+    }
+  }
+  _writeCommand(0x13);
+  for (uint16_t i = 0; i < h1; i++) // lines
+  {
+    for (uint16_t j = 0; j < w1 / ppb; j += bpp) // out bytes
+    {
+      uint8_t out_byte = 0;
+      for (uint16_t k = 0; k < bpp; k++) // in bytes (bpp per out byte)
+      {
+        uint8_t in_byte;
+        // use wb, h of bitmap for index!
+        uint32_t idx = mirror_y ? j + k + dx / ppb + uint32_t((h - 1 - (i + dy))) * wb : j + k + dx / ppb + uint32_t(i + dy) * wb;
+        if (pgm)
+        {
+#if defined(__AVR) || defined(ESP8266) || defined(ESP32)
+          in_byte = pgm_read_byte(&bitmap[idx]);
+#else
+          in_byte = bitmap[idx];
+#endif
+        }
+        else
+        {
+          in_byte = bitmap[idx];
+        }
+        if (invert) in_byte = ~in_byte;
+        for (uint16_t n = 0; n < ppb; n++) // bits, nibbles (ppb per in byte)
+        {
+          out_byte <<= 1;
+          uint8_t nibble = in_byte & mask;
+          if (nibble == mask) out_byte |= 0x01;//white
+          else if (nibble == 0x00) out_byte |= 0x00;  //black
+          else if (nibble >= grey1) out_byte |= 0x00;  //gray1
+          else out_byte |= 0x01; //gray2
+          in_byte <<= bpp;
+        }
+      }
+      _writeData(out_byte);
+    }
+  }
+  _writeCommand(0x92); // partial out
+  delay(1); // yield() to avoid WDT on ESP8266 and ESP32
+}
+
+void GxEPD2_750_T7Y::writeImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                                   int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (_initial_write) writeScreenBuffer(); // initial full screen buffer clean
+  delay(1); // yield() to avoid WDT on ESP8266 and ESP32
+  if ((w_bitmap < 0) || (h_bitmap < 0) || (w < 0) || (h < 0)) return;
+  if ((x_part < 0) || (x_part >= w_bitmap)) return;
+  if ((y_part < 0) || (y_part >= h_bitmap)) return;
+  uint16_t wb_bitmap = (w_bitmap + 7) / 8; // width bytes, bitmaps are padded
+  x_part -= x_part % 8; // byte boundary
+  w = w_bitmap - x_part < w ? w_bitmap - x_part : w; // limit
+  h = h_bitmap - y_part < h ? h_bitmap - y_part : h; // limit
+  x -= x % 8; // byte boundary
+  w = 8 * ((w + 7) / 8); // byte boundary, bitmaps are padded
+  int16_t x1 = x < 0 ? 0 : x; // limit
+  int16_t y1 = y < 0 ? 0 : y; // limit
+  uint16_t w1 = x + w < int16_t(WIDTH) ? w : int16_t(WIDTH) - x; // limit
+  uint16_t h1 = y + h < int16_t(HEIGHT) ? h : int16_t(HEIGHT) - y; // limit
+  int16_t dx = x1 - x;
+  int16_t dy = y1 - y;
+  w1 -= dx;
+  h1 -= dy;
+  if ((w1 <= 0) || (h1 <= 0)) return;
+  if (_refresh_mode == grey_refresh) _Force_Init_Full();
+  else if (_refresh_mode == full_refresh) _Init_Part();
+  _writeCommand(0x91); // partial in
+  _setPartialRamArea(x1, y1, w1, h1);
+  _writeCommand(0x13);
+  for (uint16_t i = 0; i < h1; i++)
+  {
+    for (uint16_t j = 0; j < w1 / 8; j++)
+    {
+      uint8_t data;
+      // use wb_bitmap, h_bitmap of bitmap for index!
+      uint16_t idx = mirror_y ? x_part / 8 + j + dx / 8 + uint16_t((h_bitmap - 1 - (y_part + i + dy))) * wb_bitmap : x_part / 8 + j + dx / 8 + uint16_t(y_part + i + dy) * wb_bitmap;
+      if (pgm)
+      {
+#if defined(__AVR) || defined(ESP8266) || defined(ESP32)
+        data = pgm_read_byte(&bitmap[idx]);
+#else
+        data = bitmap[idx];
+#endif
+      }
+      else
+      {
+        data = bitmap[idx];
+      }
+      if (invert) data = ~data;
+      _writeData(data);
+    }
+  }
+  _writeCommand(0x92); // partial out
+  delay(1); // yield() to avoid WDT on ESP8266 and ESP32
+}
+
+void GxEPD2_750_T7Y::writeImagePart_4G(const uint8_t bitmap[], uint8_t bpp, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                                   int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  uint16_t ppb = (bpp == 2 ? 4 : (bpp == 4 ? 2 : (bpp == 8 ? 1 : 0)));
+  uint8_t mask = (bpp == 2 ? 0xC0 : (bpp == 4 ? 0xF0 : 0xFF));
+  uint8_t grey1 = (bpp == 2 ? 0x80 : 0xA0); // demo limit for 4bpp
+  if (ppb == 0) return;
+  if (_initial_write) writeScreenBuffer(); // initial full screen buffer clean
+  delay(1); // yield() to avoid WDT on ESP8266 and ESP32
+  if ((w_bitmap < 0) || (h_bitmap < 0) || (w < 0) || (h < 0)) return;
+  if ((x_part < 0) || (x_part >= w_bitmap)) return;
+  if ((y_part < 0) || (y_part >= h_bitmap)) return;
+  int16_t wb_bitmap = (w_bitmap + ppb - 1) / ppb; // width bytes, bitmaps are padded
+  x_part -= x_part % ppb; // byte boundary
+  w = w_bitmap - x_part < w ? w_bitmap - x_part : w; // limit
+  h = h_bitmap - y_part < h ? h_bitmap - y_part : h; // limit
+  int16_t wbc = (w + 7) / 8; // width bytes on controller
+  x -= x % 8; // byte boundary on controller
+  w = wbc * 8; // byte boundary on controller
+  int16_t x1 = x < 0 ? 0 : x; // limit
+  int16_t y1 = y < 0 ? 0 : y; // limit
+  uint16_t w1 = x + w < int16_t(WIDTH) ? w : int16_t(WIDTH) - x; // limit
+  uint16_t h1 = y + h < int16_t(HEIGHT) ? h : int16_t(HEIGHT) - y; // limit
+  int16_t dx = x1 - x;
+  int16_t dy = y1 - y;
+  w1 -= dx;
+  h1 -= dy;
+  if ((w1 <= 0) || (h1 <= 0)) return;
+  _Init_4G();
+  _writeCommand(0x91); // partial in
+  _setPartialRamArea(x1, y1, w1, h1);
+  _writeCommand(0x10);
+  for (uint16_t i = 0; i < h1; i++) // lines
+  {
+    for (uint16_t j = 0; j < w1 / ppb; j += bpp) // out bytes
+    {
+      uint8_t out_byte = 0;
+      for (uint16_t k = 0; k < bpp; k++) // in bytes (bpp per out byte)
+      {
+        uint8_t in_byte;
+        // use wb_bitmap, h_bitmap of bitmap for index!
+        uint32_t idx = mirror_y ? x_part / ppb + j + k + dx / ppb + uint32_t((h_bitmap - 1 - (y_part + i + dy))) * wb_bitmap : x_part / ppb + j + k + dx / ppb + uint32_t(y_part + i + dy) * wb_bitmap;
+        if (pgm)
+        {
+#if defined(__AVR) || defined(ESP8266) || defined(ESP32)
+          in_byte = pgm_read_byte(&bitmap[idx]);
+#else
+          in_byte = bitmap[idx];
+#endif
+        }
+        else
+        {
+          in_byte = bitmap[idx];
+        }
+        if (invert) in_byte = ~in_byte;
+        for (uint16_t n = 0; n < ppb; n++) // bits, nibbles (ppb per in byte)
+        {
+          out_byte <<= 1;
+          uint8_t nibble = in_byte & mask;
+          if (nibble == mask) out_byte |= 0x01;//white
+          else if (nibble == 0x00) out_byte |= 0x00;  //black
+          else if (nibble >= grey1) out_byte |= 0x01;  //gray1
+          else out_byte |= 0x00; //gray2
+          in_byte <<= bpp;
+        }
+      }
+      _writeData(out_byte);
+    }
+  }
+  _writeCommand(0x13);
+  for (uint16_t i = 0; i < h1; i++) // lines
+  {
+    for (uint16_t j = 0; j < w1 / ppb; j += bpp) // out bytes
+    {
+      uint8_t out_byte = 0;
+      for (uint16_t k = 0; k < bpp; k++) // in bytes (bpp per out byte)
+      {
+        uint8_t in_byte;
+        // use wb_bitmap, h_bitmap of bitmap for index!
+        uint32_t idx = mirror_y ? x_part / ppb + j + k + dx / ppb + uint32_t((h_bitmap - 1 - (y_part + i + dy))) * wb_bitmap : x_part / ppb + j + k + dx / ppb + uint32_t(y_part + i + dy) * wb_bitmap;
+        if (pgm)
+        {
+#if defined(__AVR) || defined(ESP8266) || defined(ESP32)
+          in_byte = pgm_read_byte(&bitmap[idx]);
+#else
+          in_byte = bitmap[idx];
+#endif
+        }
+        else
+        {
+          in_byte = bitmap[idx];
+        }
+        if (invert) in_byte = ~in_byte;
+        for (uint16_t n = 0; n < ppb; n++) // bits, nibbles (ppb per in byte)
+        {
+          out_byte <<= 1;
+          uint8_t nibble = in_byte & mask;
+          if (nibble == mask) out_byte |= 0x01;//white
+          else if (nibble == 0x00) out_byte |= 0x00;  //black
+          else if (nibble >= grey1) out_byte |= 0x00;  //gray1
+          else out_byte |= 0x01; //gray2
+          in_byte <<= bpp;
+        }
+      }
+      _writeData(out_byte);
+    }
+  }
+  _writeCommand(0x92); // partial out
+  delay(1); // yield() to avoid WDT on ESP8266 and ESP32
+}
+
+void GxEPD2_750_T7Y::writeImage(const uint8_t* black, const uint8_t* color, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (black)
+  {
+    writeImage(black, x, y, w, h, invert, mirror_y, pgm);
+  }
+}
+
+void GxEPD2_750_T7Y::writeImagePart(const uint8_t* black, const uint8_t* color, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                                   int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (black)
+  {
+    writeImagePart(black, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+  }
+}
+
+void GxEPD2_750_T7Y::writeNative(const uint8_t* data1, const uint8_t* data2, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (data1)
+  {
+    writeImage(data1, x, y, w, h, invert, mirror_y, pgm);
+  }
+}
+
+void GxEPD2_750_T7Y::drawImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  writeImage(bitmap, x, y, w, h, invert, mirror_y, pgm);
+  refresh(x, y, w, h);
+  writeImage(bitmap, x, y, w, h, invert, mirror_y, pgm);
+}
+
+void GxEPD2_750_T7Y::drawImage_4G(const uint8_t bitmap[], uint8_t bpp, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  writeImage_4G(bitmap, bpp, x, y, w, h, invert, mirror_y, pgm);
+  refresh(x, y, w, h);
+}
+
+void GxEPD2_750_T7Y::drawImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                                  int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  writeImagePart(bitmap, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+  refresh(x, y, w, h);
+  writeImagePart(bitmap, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+}
+
+void GxEPD2_750_T7Y::drawImagePart_4G(const uint8_t bitmap[], uint8_t bpp, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                                  int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  writeImagePart_4G(bitmap, bpp, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+  refresh(x, y, w, h);
+}
+
+void GxEPD2_750_T7Y::drawImage(const uint8_t* black, const uint8_t* color, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  writeImage(black, color, x, y, w, h, invert, mirror_y, pgm);
+  refresh(x, y, w, h);
+  writeImage(black, color, x, y, w, h, invert, mirror_y, pgm);
+}
+
+void GxEPD2_750_T7Y::drawImagePart(const uint8_t* black, const uint8_t* color, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                                  int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  writeImagePart(black, color, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+  refresh(x, y, w, h);
+  writeImagePart(black, color, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+}
+
+void GxEPD2_750_T7Y::drawNative(const uint8_t* data1, const uint8_t* data2, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  writeNative(data1, data2, x, y, w, h, invert, mirror_y, pgm);
+  refresh(x, y, w, h);
+  writeNative(data1, data2, x, y, w, h, invert, mirror_y, pgm);
+}
+
+void GxEPD2_750_T7Y::refresh(bool partial_update_mode)
+{
+  if (partial_update_mode) refresh(0, 0, WIDTH, HEIGHT);
+  else
+  {
+    if (_refresh_mode == forced_full_refresh) _refresh_mode = full_refresh;
+    if (_refresh_mode == fast_refresh) _Init_Full();
+    if (_refresh_mode == grey_refresh) _Update_4G();
+    else _Update_Full();
+    _initial_refresh = false; // initial full update done
+  }
+}
+
+void GxEPD2_750_T7Y::refresh(int16_t x, int16_t y, int16_t w, int16_t h)
+{
+  if (_initial_refresh) return refresh(false); // initial update needs be full update
+  if (_refresh_mode == forced_full_refresh) return refresh(false);
+  // intersection with screen
+  int16_t w1 = x < 0 ? w + x : w; // reduce
+  int16_t h1 = y < 0 ? h + y : h; // reduce
+  int16_t x1 = x < 0 ? 0 : x; // limit
+  int16_t y1 = y < 0 ? 0 : y; // limit
+  w1 = x1 + w1 < int16_t(WIDTH) ? w1 : int16_t(WIDTH) - x1; // limit
+  h1 = y1 + h1 < int16_t(HEIGHT) ? h1 : int16_t(HEIGHT) - y1; // limit
+  if ((w1 <= 0) || (h1 <= 0)) return; 
+  // make x1, w1 multiple of 8
+  w1 += x1 % 8;
+  if (w1 % 8 > 0) w1 += 8 - w1 % 8;
+  x1 -= x1 % 8;
+  if (_refresh_mode == full_refresh) _Init_Part();
+  if (usePartialUpdateWindow) _writeCommand(0x91); // partial in
+  else if (_refresh_mode == grey_refresh) _writeCommand(0x91); // partial in
+  _setPartialRamArea(x1, y1, w1, h1);
+  if (_refresh_mode == grey_refresh) _Update_4G();
+  else _Update_Part();
+  if (usePartialUpdateWindow) _writeCommand(0x92); // partial out
+  else if (_refresh_mode == grey_refresh) _writeCommand(0x92); // partial out
+}
+
+void GxEPD2_750_T7Y::powerOff(void)
+{
+  _PowerOff();
+}
+
+void GxEPD2_750_T7Y::hibernate()
+{
+  _PowerOff();
+  if (_rst >= 0)
+  {
+    _writeCommand(0x07); // deep sleep
+    _writeData(0xA5);    // check code
+    _hibernating = true;
+  }
+}
+
+void GxEPD2_750_T7Y::_setPartialRamArea(uint16_t x, uint16_t y, uint16_t w, uint16_t h)
+{
+  uint16_t xe = (x + w - 1) | 0x0007; // byte boundary inclusive (last byte)
+  uint16_t ye = y + h - 1;
+  x &= 0xFFF8; // byte boundary
+  _writeCommand(0x90); // partial window
+  _writeData(x / 256);
+  _writeData(x % 256);
+  _writeData(xe / 256);
+  _writeData(xe % 256);
+  _writeData(y / 256);
+  _writeData(y % 256);
+  _writeData(ye / 256);
+  _writeData(ye % 256);
+  _writeData(0x01); // don't see any difference
+  //_writeData(0x00); // don't see any difference
+}
+
+void GxEPD2_750_T7Y::_PowerOn()
+{
+  if (!_power_is_on)
+  {
+    _writeCommand(0x04);
+    _waitWhileBusy("_PowerOn", power_on_time);
+  }
+  _power_is_on = true;
+}
+
+void GxEPD2_750_T7Y::_PowerOff()
+{
+  if (_power_is_on)
+  {
+    _writeCommand(0x02); // power off
+    _waitWhileBusy("_PowerOff", power_off_time);
+  }
+  _power_is_on = false;
+  _refresh_mode = full_refresh;
+}
+
+void GxEPD2_750_T7Y::_InitDisplay()
+{
+  if (_hibernating) _reset();
+  _writeCommand(0x01); // POWER SETTING
+  _writeData (0x07); //
+  _writeData (0x17); // VGH=20V,VGL=-20V
+  _writeData (0x3a); // VDH=14V
+  _writeData (0x3a); // VDL=-14V
+  _writeData (0x03); // VDHR=3V
+  _writeCommand(0x00); //PANEL SETTING
+  _writeData(0x1f); //KW: 3f, KWR: 2F, BWROTP: 0f, BWOTP: 1f
+  _writeCommand(0x06); // boost soft start
+  _writeData (0x17);   
+  _writeData (0x17);   
+  _writeData (0x28);   
+  _writeData (0x17);   
+  _writeCommand(0x61); //tres
+  _writeData (0x03); //source 800
+  _writeData (0x20);
+  _writeData (0x01); //gate 480
+  _writeData (0xE0);
+  _writeCommand(0x15);
+  _writeData(0x00);
+  _writeCommand(0x50); //VCOM AND DATA INTERVAL SETTING
+  _writeData(0x10);   
+  _writeData(0x07);
+  _writeCommand(0x60); //TCON SETTING
+  _writeData(0x22);
+}
+
+// full screen update LUT 0~3 gray
+const unsigned char GxEPD2_750_T7Y::lut_20_vcom0_4G[] PROGMEM =
+{
+  0x00, 0x0A, 0x00, 0x00, 0x00, 0x01,
+  0x60, 0x14, 0x14, 0x00, 0x00, 0x01,
+  0x00, 0x14, 0x00, 0x00, 0x00, 0x01,
+  0x00, 0x13, 0x0A, 0x01, 0x00, 0x01,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+//R21
+const unsigned char GxEPD2_750_T7Y::lut_21_ww_4G[] PROGMEM =
+{
+  0x40, 0x0A, 0x00, 0x00, 0x00, 0x01,
+  0x90, 0x14, 0x14, 0x00, 0x00, 0x01,
+  0x10, 0x14, 0x0A, 0x00, 0x00, 0x01,
+  0xA0, 0x13, 0x01, 0x00, 0x00, 0x01,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+//R22H  r
+const unsigned char GxEPD2_750_T7Y::lut_22_bw_4G[] PROGMEM =
+{
+  0x40, 0x0A, 0x00, 0x00, 0x00, 0x01,
+  0x90, 0x14, 0x14, 0x00, 0x00, 0x01,
+  0x00, 0x14, 0x0A, 0x00, 0x00, 0x01,
+  0x99, 0x0C, 0x01, 0x03, 0x04, 0x01,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+//R23H  w
+const unsigned char GxEPD2_750_T7Y::lut_23_wb_4G[] PROGMEM =
+{
+  0x40, 0x0A, 0x00, 0x00, 0x00, 0x01,
+  0x90, 0x14, 0x14, 0x00, 0x00, 0x01,
+  0x00, 0x14, 0x0A, 0x00, 0x00, 0x01,
+  0x99, 0x0B, 0x04, 0x04, 0x01, 0x01,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+//R24H  b
+const unsigned char GxEPD2_750_T7Y::lut_24_bb_4G[] PROGMEM =
+{
+  0x80, 0x0A, 0x00, 0x00, 0x00, 0x01,
+  0x90, 0x14, 0x14, 0x00, 0x00, 0x01,
+  0x20, 0x14, 0x0A, 0x00, 0x00, 0x01,
+  0x50, 0x13, 0x01, 0x00, 0x00, 0x01,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+// experimental partial screen update LUTs with balanced charge
+// LUTs are filled with zeroes
+
+#define T1 30 // charge balance pre-phase
+#define T2  5 // optional extension
+#define T3 30 // color change phase (b/w)
+#define T4  5 // optional extension for one color
+
+const unsigned char GxEPD2_750_T7Y::lut_20_LUTC_partial[] PROGMEM =
+{
+  0x00, T1, T2, T3, T4, 1, // 00 00 00 00
+};
+
+const unsigned char GxEPD2_750_T7Y::lut_21_LUTWW_partial[] PROGMEM =
+{ // 10 w
+  0x00, T1, T2, T3, T4, 1, // 00 00 00 00
+};
+
+const unsigned char GxEPD2_750_T7Y::lut_22_LUTKW_partial[] PROGMEM =
+{ // 10 w
+  //0x48, T1, T2, T3, T4, 1, // 01 00 10 00
+  0x5A, T1, T2, T3, T4, 1, // 01 01 10 10 more white
+};
+
+const unsigned char GxEPD2_750_T7Y::lut_23_LUTWK_partial[] PROGMEM =
+{ // 01 b
+  0x84, T1, T2, T3, T4, 1, // 10 00 01 00
+  //0xA5, T1, T2, T3, T4, 1, // 10 10 01 01 more black
+};
+
+const unsigned char GxEPD2_750_T7Y::lut_24_LUTKK_partial[] PROGMEM =
+{ // 01 b
+  0x00, T1, T2, T3, T4, 1, // 00 00 00 00
+};
+
+const unsigned char GxEPD2_750_T7Y::lut_25_LUTBD_partial[] PROGMEM =
+{
+  0x00, T1, T2, T3, T4, 1, // 00 00 00 00
+};
+
+void GxEPD2_750_T7Y::_Force_Init_Full()
+{
+  _Init_Full();
+  _refresh_mode = forced_full_refresh;
+}
+
+void GxEPD2_750_T7Y::_Init_Full()
+{
+  _InitDisplay();
+  _writeCommand(0x00); // panel setting
+  _writeData(0x1f);    // full update LUT from OTP
+  _PowerOn();
+  _refresh_mode = full_refresh;
+}
+
+void GxEPD2_750_T7Y::_Init_4G()
+{
+  _InitDisplay();
+  _writeCommand(0x00); //panel setting
+  _writeData(0x3f); // 4G update LUT from registers
+  _writeCommand(0x50); // VCOM AND DATA INTERVAL SETTING
+  _writeData(0x31);    // LUTBD
+  _writeData(0x07);
+  _writeCommand(0x20);
+  _writeDataPGM(lut_20_vcom0_4G, sizeof(lut_20_vcom0_4G));
+  _writeCommand(0x21);
+  _writeDataPGM(lut_21_ww_4G, sizeof(lut_21_ww_4G));
+  _writeCommand(0x22);
+  _writeDataPGM(lut_22_bw_4G, sizeof(lut_22_bw_4G));
+  _writeCommand(0x23);
+  _writeDataPGM(lut_23_wb_4G, sizeof(lut_23_wb_4G));
+  _writeCommand(0x24);
+  _writeDataPGM(lut_24_bb_4G, sizeof(lut_24_bb_4G));
+  _writeCommand(0x25);
+  //_writeDataPGM(lut_21_ww_4G, sizeof(lut_21_ww_4G));
+  _writeDataPGM(lut_25_LUTBD_partial, sizeof(lut_25_LUTBD_partial), 42 - sizeof(lut_25_LUTBD_partial));
+  _PowerOn();
+  _refresh_mode = grey_refresh;
+}
+
+void GxEPD2_750_T7Y::_Init_Part()
+{
+  _InitDisplay();
+  _writeCommand(0x00); //panel setting
+  _writeData(hasFastPartialUpdate ? 0x3f : 0x1f); // partial update LUT from registers
+  _writeCommand(0x82); // vcom_DC setting
+  //_writeData (0x2C); // -2.3V same value as in OTP
+  _writeData (0x26); // -2.0V
+  //_writeData (0x1C); // -1.5V
+  _writeCommand(0x50); // VCOM AND DATA INTERVAL SETTING
+  _writeData(0x39);    // LUTBD, N2OCP: copy new to old
+  _writeData(0x07);
+  _writeCommand(0x20);
+  _writeDataPGM(lut_20_LUTC_partial, sizeof(lut_20_LUTC_partial), 42 - sizeof(lut_20_LUTC_partial));
+  _writeCommand(0x21);
+  _writeDataPGM(lut_21_LUTWW_partial, sizeof(lut_21_LUTWW_partial), 42 - sizeof(lut_21_LUTWW_partial));
+  _writeCommand(0x22);
+  _writeDataPGM(lut_22_LUTKW_partial, sizeof(lut_22_LUTKW_partial), 42 - sizeof(lut_22_LUTKW_partial));
+  _writeCommand(0x23);
+  _writeDataPGM(lut_23_LUTWK_partial, sizeof(lut_23_LUTWK_partial), 42 - sizeof(lut_23_LUTWK_partial));
+  _writeCommand(0x24);
+  _writeDataPGM(lut_24_LUTKK_partial, sizeof(lut_24_LUTKK_partial), 42 - sizeof(lut_24_LUTKK_partial));
+  _writeCommand(0x25);
+  _writeDataPGM(lut_25_LUTBD_partial, sizeof(lut_25_LUTBD_partial), 42 - sizeof(lut_25_LUTBD_partial));
+  _PowerOn();
+  _refresh_mode = fast_refresh;
+}
+
+void GxEPD2_750_T7Y::_Update_Full()
+{
+  _writeCommand(0x12); //display refresh
+  _waitWhileBusy("_Update_Full", full_refresh_time);
+}
+
+void GxEPD2_750_T7Y::_Update_4G()
+{
+  _writeCommand(0x12); //display refresh
+  _waitWhileBusy("_Update_4G", full_refresh_time);
+}
+
+void GxEPD2_750_T7Y::_Update_Part()
+{
+  _writeCommand(0x12); //display refresh
+  _waitWhileBusy("_Update_Part", partial_refresh_time);
+}

--- a/src/epd/GxEPD2_750_T7Y.h
+++ b/src/epd/GxEPD2_750_T7Y.h
@@ -1,0 +1,103 @@
+// Based on GxEPD2_750_T7.h
+// Panel: GDEY075T7 : https://www.good-display.com/product/396.html
+//
+// Display Library for SPI e-paper panels from Dalian Good Display and boards from Waveshare.
+// Requires HW SPI and Adafruit_GFX. Caution: the e-paper panels require 3.3V supply AND data lines!
+//
+// based on Demo Example from Good Display: 
+// Panel: GDEW075T7 : http://www.e-paper-display.com/products_detail/productId=456.html
+// Controller: GD7965 : http://www.e-paper-display.com/download_detail/downloadsId=821.html
+//
+// Author: Jean-Marc Zingg
+//
+// Version: see library.properties
+//
+// Library: https://github.com/ZinggJM/GxEPD2
+
+#ifndef _GxEPD2_750_T7Y_H_
+#define _GxEPD2_750_T7Y_H_
+
+#include "../GxEPD2_4G_EPD.h"
+
+class GxEPD2_750_T7Y : public GxEPD2_4G_EPD
+{
+  public:
+    // attributes
+    static const uint16_t WIDTH = 800;
+    static const uint16_t HEIGHT = 480;
+    static const GxEPD2_4G::Panel panel = GxEPD2_4G::GDEW075T7;
+    static const bool hasColor = false;
+    static const bool hasPartialUpdate = true;
+    static const bool usePartialUpdateWindow = false; // set false for better image
+    static const bool hasFastPartialUpdate = true; // set this false to force full refresh always
+    static const uint16_t power_on_time = 140; // ms, e.g. 134460us
+    static const uint16_t power_off_time = 42; // ms, e.g. 40033us
+    static const uint16_t full_refresh_time = 4200; // ms, e.g. 4108238us
+    static const uint16_t partial_refresh_time = 1600; // ms, e.g. 1584124us
+    // constructor
+    GxEPD2_750_T7Y(int16_t cs, int16_t dc, int16_t rst, int16_t busy);
+    // methods (virtual)
+    //  Support for Bitmaps (Sprites) to Controller Buffer and to Screen
+    void clearScreen(uint8_t value = 0xFF); // init controller memory and screen (default white)
+    void writeScreenBuffer(uint8_t value = 0xFF); // init controller memory (default white)
+    // write to controller memory, without screen refresh; x and w should be multiple of 8
+    void writeImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void writeImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                        int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void writeImage(const uint8_t* black, const uint8_t* color, int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void writeImage_4G(const uint8_t bitmap[], uint8_t bpp, int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void writeImagePart(const uint8_t* black, const uint8_t* color, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                        int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void writeImagePart_4G(const uint8_t bitmap[], uint8_t bpp, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                        int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    // for differential update: set current and previous buffers equal (for fast partial update to work correctly)
+    // done by controller (N2OCP); override with empty code
+    void writeImageAgain(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false) {};
+    void writeImagePartAgain(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                             int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false) {};
+    // write sprite of native data to controller memory, without screen refresh; x and w should be multiple of 8
+    void writeNative(const uint8_t* data1, const uint8_t* data2, int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    // write to controller memory, with screen refresh; x and w should be multiple of 8
+    void drawImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void drawImage_4G(const uint8_t bitmap[], uint8_t bpp, int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void drawImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                       int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void drawImagePart_4G(const uint8_t bitmap[], uint8_t bpp, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                       int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void drawImage(const uint8_t* black, const uint8_t* color, int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void drawImagePart(const uint8_t* black, const uint8_t* color, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                       int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    // write sprite of native data to controller memory, with screen refresh; x and w should be multiple of 8
+    void drawNative(const uint8_t* data1, const uint8_t* data2, int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void refresh(bool partial_update_mode = false); // screen refresh from controller memory to full screen
+    void refresh(int16_t x, int16_t y, int16_t w, int16_t h); // screen refresh from controller memory, partial screen
+    void powerOff(); // turns off generation of panel driving voltages, avoids screen fading over time
+    void hibernate(); // turns powerOff() and sets controller to deep sleep for minimum power use, ONLY if wakeable by RST (rst >= 0)
+  private:
+    void _setPartialRamArea(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
+    void _PowerOn();
+    void _PowerOff();
+    void _InitDisplay();
+    void _Force_Init_Full();
+    void _Init_Full();
+    void _Init_4G();
+    void _Init_Part();
+    void _Update_Full();
+    void _Update_4G();
+    void _Update_Part();
+  private:
+    enum {full_refresh, grey_refresh, fast_refresh, forced_full_refresh} _refresh_mode;
+    static const unsigned char lut_20_vcom0_4G[];
+    static const unsigned char lut_21_ww_4G[];
+    static const unsigned char lut_22_bw_4G[];
+    static const unsigned char lut_23_wb_4G[];
+    static const unsigned char lut_24_bb_4G[];
+    static const unsigned char lut_20_LUTC_partial[];
+    static const unsigned char lut_21_LUTWW_partial[];
+    static const unsigned char lut_22_LUTKW_partial[];
+    static const unsigned char lut_23_LUTWK_partial[];
+    static const unsigned char lut_24_LUTKK_partial[];
+    static const unsigned char lut_25_LUTBD_partial[];
+};
+
+#endif


### PR DESCRIPTION
- added support for GDEY075T7 480x800 
- only adjustments were made to "_InitDisplay" compared to the GDEW075T7 - "_Init_Full", "_Init_4G" and "_Init_Part" were not checked

--

Thread: https://forum.arduino.cc/t/gxepd2-4g-supports-gdey075t7/1270603/10

--

**Version 1.0.7**

![IMG_3597](https://github.com/ZinggJM/GxEPD2_4G/assets/264264/5b9e371a-39b4-4413-955c-36df9c831a9c)

--

**Version 1.0.8-dev**

![IMG_3633](https://github.com/ZinggJM/GxEPD2_4G/assets/264264/13c5214c-5950-4c87-8215-26708e354814)
